### PR TITLE
fix license url

### DIFF
--- a/CASE-STUDIES-AND-EXPERIENCES.md
+++ b/CASE-STUDIES-AND-EXPERIENCES.md
@@ -14,7 +14,7 @@ pitch: The OWASP Security Qualitative Metrics is the most detailed list of metri
 
 # ![Project Logo](images/logo3_small.png) Case Studies and Experiences 
 # [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-blue.svg)](https://owasp.org/projects/)
- [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/Naereen/StrapDown.js/blob/master/LICENSE)
+ [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE)
 
  [![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/releases)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,7 +13,7 @@ pitch: The OWASP Security Qualitative Metrics is the most detailed list of metri
 
 # ![Project Logo](images/logo3_small.png) OWASP Security Qualitative Metrics  
 # [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-blue.svg)](https://owasp.org/projects/)
- [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/Naereen/StrapDown.js/blob/master/LICENSE)
+ [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE)
 
  [![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/releases)
 

--- a/METHODOLOGY-AND-BACKGROUND.md
+++ b/METHODOLOGY-AND-BACKGROUND.md
@@ -16,7 +16,7 @@ pitch: The OWASP Security Qualitative Metrics is the most detailed list of metri
 
 # [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-blue.svg)](https://owasp.org/projects/)
 
- [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/Naereen/StrapDown.js/blob/master/LICENSE)
+ [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE)
 
  [![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/releases)
  

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -15,7 +15,7 @@ pitch: The OWASP Security Qualitative Metrics is the most detailed list of metri
 
 
 # [![OWASP Flagship](https://img.shields.io/badge/owasp-flagship-blue.svg)](https://owasp.org/projects/)
- [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/Naereen/StrapDown.js/blob/master/LICENSE)
+ [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE)
 
  [![GitHub release](https://img.shields.io/github/release/Naereen/StrapDown.js.svg)](https://github.com/OWASP/www-project-security-qualitative-metrics/releases)
 

--- a/info.md
+++ b/info.md
@@ -18,5 +18,5 @@
 * [changes](#)
 
 ### Licensing
-The content is free to use it under the terms of the [MIT License](https://www.apache.org/licenses/LICENSE-2.0). OWASP  Security Qualitative Metrics and any contributions are Copyright © by Ferda Özdemir Sönmez 2020.
+The content is free to use it under the terms of the [MIT License](https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE). OWASP  Security Qualitative Metrics and any contributions are Copyright © by Ferda Özdemir Sönmez 2020.
 


### PR DESCRIPTION
https://github.com/Naereen/StrapDown.js/blob/master/LICENSE is wrong for this repo, so correct url  is https://github.com/OWASP/www-project-security-qualitative-metrics/blob/master/LICENSE .